### PR TITLE
Make service options optional in typings

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -13,7 +13,7 @@ If no baseline image is found the image is automatically copied to the baselinef
 ### `baselineFolder`
 
 -   **Type:** `String`
--   **Mandatory:** Yes
+-   **Mandatory:** No
 
 The directory that will hold all the baseline images that are used to execute the comparison
 
@@ -178,7 +178,7 @@ Save the images per device in a separate folder
 ### `screenshotPath`
 
 -   **Type:** `String`
--   **Mandatory:** Yes
+-   **Mandatory:** No
 
 The directory that will hold all the actual / difference screenshots
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,14 +48,6 @@ interface PluginOptions extends CompareOptions, CompareScreenOptions {
     debug?: boolean
     imageNameFormat?: string
     savePerDevice?: boolean
-    output?: {
-        largeImageThreshold?: number
-        errorColor?: {
-            red: number
-            green: number
-            blue: number
-        }
-    }
 }
 
 interface SaveElementMethodOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,8 +42,8 @@ declare global {
 }
 
 interface PluginOptions extends CompareOptions, CompareScreenOptions {
-    baselineFolder: string
-    screenshotPath: string
+    baselineFolder?: string
+    screenshotPath?: string
     autoSaveBaseline?: boolean
     debug?: boolean
     imageNameFormat?: string


### PR DESCRIPTION
I found out that, even though the options are required by the service, they have to be made optional.
If you load the service typings globally in tsconfig, which is the preferred way according to the WDIO docs, it will apply these typings to any wdio config which uses typescript. This leads to that every service definition with additional properties now requires you to add a 'baselineFolder' and 'screenshotPath' to the options.

edit: Also removed some invalid options

Sorry for the oversight on the first PR.